### PR TITLE
Top like sorting

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,7 @@ Top like program monitor for gnatsd written in Go.
 ```sh
 go get github.com/nats-io/nats-top
 
-Usage: nats-top [-s server] [-m monitor] [-n num_connections] [-d delay_secs]
+Usage: nats-top [-s server] [-m monitor] [-n num_connections] [-d delay_secs] [--sort by]
 ```
 
 Example Output:

--- a/readme.md
+++ b/readme.md
@@ -17,6 +17,8 @@ Server:
   Out:  Msgs: 2.2K  Bytes: 8.0K  Msgs/Sec: 1.0  Bytes/Sec: 1.0
 
 Connections: 1
-  HOST                 CID      SUBS    PENDING     MSGS_TO     MSGS_FROM   BYTES_TO    BYTES_FROM
+  HOST                 CID      SUBS    PENDING     MSGS_TO     MSGS_FROM   BYTES_TO    BYTES_FROM  LANG  VERSION
   127.0.0.1:56358      4        1       0           1.2K        1.2K        4.5K        4.5K
 ```
+
+It also supports ordering during the nats-top session by pressing `o` then `ENTER`.

--- a/util/toputils.go
+++ b/util/toputils.go
@@ -9,6 +9,90 @@ import (
 	"github.com/nats-io/gnatsd/server"
 )
 
+type ByCid []*server.ConnInfo
+
+func (d ByCid) Len() int {
+	return len(d)
+}
+func (d ByCid) Swap(i, j int) {
+	d[i], d[j] = d[j], d[i]
+}
+func (d ByCid) Less(i, j int) bool {
+	return d[i].Cid < d[j].Cid
+}
+
+type BySubs []*server.ConnInfo
+
+func (d BySubs) Len() int {
+	return len(d)
+}
+func (d BySubs) Swap(i, j int) {
+	d[i], d[j] = d[j], d[i]
+}
+func (d BySubs) Less(i, j int) bool {
+	return d[i].NumSubs < d[j].NumSubs
+}
+
+type ByPending []*server.ConnInfo
+
+func (d ByPending) Len() int {
+	return len(d)
+}
+func (d ByPending) Swap(i, j int) {
+	d[i], d[j] = d[j], d[i]
+}
+func (d ByPending) Less(i, j int) bool {
+	return d[i].Pending < d[j].Pending
+}
+
+type ByMsgsTo []*server.ConnInfo
+
+func (d ByMsgsTo) Len() int {
+	return len(d)
+}
+func (d ByMsgsTo) Swap(i, j int) {
+	d[i], d[j] = d[j], d[i]
+}
+func (d ByMsgsTo) Less(i, j int) bool {
+	return d[i].OutMsgs < d[j].OutMsgs
+}
+
+type ByMsgsFrom []*server.ConnInfo
+
+func (d ByMsgsFrom) Len() int {
+	return len(d)
+}
+func (d ByMsgsFrom) Swap(i, j int) {
+	d[i], d[j] = d[j], d[i]
+}
+func (d ByMsgsFrom) Less(i, j int) bool {
+	return d[i].InMsgs < d[j].InMsgs
+}
+
+type ByBytesTo []*server.ConnInfo
+
+func (d ByBytesTo) Len() int {
+	return len(d)
+}
+func (d ByBytesTo) Swap(i, j int) {
+	d[i], d[j] = d[j], d[i]
+}
+func (d ByBytesTo) Less(i, j int) bool {
+	return d[i].OutBytes < d[j].OutBytes
+}
+
+type ByBytesFrom []*server.ConnInfo
+
+func (d ByBytesFrom) Len() int {
+	return len(d)
+}
+func (d ByBytesFrom) Swap(i, j int) {
+	d[i], d[j] = d[j], d[i]
+}
+func (d ByBytesFrom) Less(i, j int) bool {
+	return d[i].InBytes < d[j].InBytes
+}
+
 // Takes a path and options, then returns a serialized connz, varz, or routez response
 func Request(path string, opts map[string]interface{}) (interface{}, error) {
 	var statz interface{}


### PR DESCRIPTION
Implements changing the sorting order during the nats-top session by pressing `o ENTER`.
Also includes the `--sort by` flag to the options from the command line.

```
./nats-top  -m 8333 --sort $sort_order
Sort by options: 
         bytes_to
         bytes_from
         cid
         subs
         pending
         msgs_to
         msgs_from
```

Example:

```
Server:
  Load: CPU: 0.0%  Memory: 4.7M
  In:   Msgs: 146.8K  Bytes: 701.3K  Msgs/Sec: 1.0  Bytes/Sec: 1.0
  Out:  Msgs: 147.7K  Bytes: 705.7K  Msgs/Sec: 1.0  Bytes/Sec: 1.0
sort by [cid]: 
Connections: 7
  HOST                 CID      SUBS    PENDING     MSGS_TO     MSGS_FROM   BYTES_TO    BYTES_FROM  LANG        VERSION   
  127.0.0.1:50402      5        1       0           12.5K       12.5K       59.9K       59.9K                             
  127.0.0.1:50413      6        1       0           12.4K       12.4K       59.2K       59.2K                             
  127.0.0.1:50414      7        1       0           12.5K       12.5K       59.7K       59.7K                             
  127.0.0.1:50415      8        1       0           12.6K       12.6K       60.2K       60.2K                             
  127.0.0.1:50416      9        1       0           12.8K       12.8K       60.8K       60.8K                             
  127.0.0.1:50417      10       1       0           12.6K       12.6K       60.3K       60.4K                             
  127.0.0.1:50420      11       1       0           12.5K       12.5K       59.5K       59.5K                             
```