### PR TITLE
Adopt termui framework and gnatsd 0.6.4 changes

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,7 @@
 
+- [X] Show lang and version of client
+- [X] Dashboard style for metrics
+- [X] top like sort and limit
 - [ ] Include /routesz info
-- [ ] Show lang and version of client
-- [ ] Dashboard style for metrics
+- [ ] Enable prepend '+/-' for asc/desc sorting
+- [ ] Toggle for displaying subscriptions info per conn

--- a/nats-top.go
+++ b/nats-top.go
@@ -119,15 +119,15 @@ func monitorStats(
 	first := true
 	pollTime = time.Now()
 
-	for {
-		// Note that delay defines the sampling rate as well
-		if val, ok := opts["delay"].(int); ok {
-			time.Sleep(time.Duration(val) * time.Second)
-		} else {
-			log.Fatalf("error: could not use %s as a refreshing interval", opts["delay"])
-			break
-		}
+	var delay int
+	if val, ok := opts["delay"].(int); ok {
+		delay = val
+	} else {
+		log.Fatalf("error: could not use %s as a refreshing interval", opts["delay"])
+		return
+	}
 
+	for {
 		// Wrap collected info in a Stats struct
 		stats := &Stats{
 			Varz:  &gnatsd.Varz{},
@@ -201,6 +201,8 @@ func monitorStats(
 
 		// Send update
 		statsCh <- stats
+
+		time.Sleep(time.Duration(delay) * time.Second)
 	}
 }
 

--- a/nats-top.go
+++ b/nats-top.go
@@ -379,11 +379,8 @@ func StartUI(
 					default:
 						go func() {
 							// Has to be at least of the same length as sort by header
-							emptyPadding := ""
-							if len(optionBuf) < 5 {
-								emptyPadding = "   "
-							}
-							fmt.Printf("\033[1;1H\033[6;1Hinvalid order: %s%s", emptyPadding, optionBuf)
+							emptyPadding := "       "
+							fmt.Printf("\033[1;1H\033[6;1Hinvalid order: %s%s", optionBuf, emptyPadding)
 							waitingSortOption = false
 							time.Sleep(1 * time.Second)
 							refreshOptionHeader()

--- a/nats-top.go
+++ b/nats-top.go
@@ -249,7 +249,7 @@ func generateParagraph(
 		"MSGS_TO", "MSGS_FROM", "BYTES_TO", "BYTES_FROM",
 		"LANG", "VERSION")
 	text += connRows
-	connValues := "  %-20s %-8d %-6d  %-10d  %-10s  %-10s  %-10s  %-10s  %-7s  %-7s\n"
+	connValues := "  %-20s %-8d %-6d  %-10s  %-10s  %-10s  %-10s  %-10s  %-7s  %-7s\n"
 
 	switch opts["sort"] {
 	case SortByCid:
@@ -268,7 +268,7 @@ func generateParagraph(
 
 	for _, conn := range stats.Connz.Conns {
 		host := fmt.Sprintf("%s:%d", conn.IP, conn.Port)
-		connLine := fmt.Sprintf(connValues, host, conn.Cid, conn.NumSubs, conn.Pending,
+		connLine := fmt.Sprintf(connValues, host, conn.Cid, conn.NumSubs, Psize(int64(conn.Pending)),
 			Psize(conn.OutMsgs), Psize(conn.InMsgs), Psize(conn.OutBytes), Psize(conn.InBytes),
 			conn.Lang, conn.Version)
 		text += connLine

--- a/nats-top.go
+++ b/nats-top.go
@@ -2,32 +2,32 @@
 package main
 
 import (
-	"bufio"
 	"flag"
 	"fmt"
 	"log"
 	"os"
-	"os/signal"
 	"sort"
-	"sync"
-	"syscall"
 	"time"
 
-	"github.com/nats-io/gnatsd/server"
+	ui "github.com/gizak/termui"
+	gnatsd "github.com/nats-io/gnatsd/server"
 	. "github.com/nats-io/nats-top/util"
 )
 
-func usage() {
-	log.Fatalf("Usage: nats-top [-s server] [-m monitor_port] [-n num_connections] [-d delay_secs] [--sort by]\n")
-}
+const version = "0.1.0"
 
 var (
-	host   = flag.String("s", "127.0.0.1", "The nats server host")
-	port   = flag.Int("m", 8333, "The nats server monitoring port")
-	conns  = flag.Int("n", 1024, "Num of connections")
-	delay  = flag.Int("d", 1, "Delay in monitoring interval in seconds")
-	sortBy = flag.String("sort", "cid", "Value for which to sort by the connections")
+	host        = flag.String("s", "127.0.0.1", "The nats server host.")
+	port        = flag.Int("m", 8222, "The nats server monitoring port.")
+	conns       = flag.Int("n", 1024, "Maximum number of connections to poll.")
+	delay       = flag.Int("d", 1, "Refresh interval in seconds.")
+	sortBy      = flag.String("sort", "cid", "Value for which to sort by the connections.")
+	showVersion = flag.Bool("v", false, "Show nats-top version")
 )
+
+func usage() {
+	log.Fatalf("Usage: nats-top [-s server] [-m monitor_port] [-n num_connections] [-d delay_secs] [-sort by]\n")
+}
 
 func init() {
 	log.SetFlags(0)
@@ -36,114 +36,69 @@ func init() {
 }
 
 func main() {
-	opts := make(map[string]interface{})
+
+	if *showVersion {
+		log.Printf("nats-top v%s", version)
+		os.Exit(0)
+	}
+
+	opts := map[string]interface{}{}
 	opts["host"] = *host
 	opts["port"] = *port
 	opts["conns"] = *conns
 	opts["delay"] = *delay
-	opts["header"] = ""
 
 	if opts["host"] == nil || opts["port"] == nil {
-		log.Fatalf("Please specify the monitoring port for NATS.")
+		log.Fatalf("Please specify the monitoring port for NATS.\n")
 		usage()
 	}
 
-	sortingOptions := map[string]bool{
-		"cid":        true,
-		"subs":       true,
-		"pending":    true,
-		"msgs_to":    true,
-		"msgs_from":  true,
-		"bytes_to":   true,
-		"bytes_from": true,
+	sortOpt := gnatsd.SortOpt(*sortBy)
+	switch sortOpt {
+	case SortByCid, SortBySubs, SortByOutMsgs, SortByInMsgs, SortByOutBytes, SortByInBytes:
+		opts["sort"] = sortOpt
+	default:
+		log.Printf("nats-top: not a valid option to sort by: %s\n", sortOpt)
 	}
 
-	if !sortingOptions[*sortBy] {
-		log.Printf("nats-top: not a valid option to sort by: %s\n", *sortBy)
-		log.Println("Sort by options: ")
-		for k, _ := range sortingOptions {
-			log.Printf("         %s\n", k)
-		}
-		usage()
-	}
-	opts["sort"] = *sortBy
-
-	// Smoke test the server once before starting
-	_, err := Request("/varz", opts)
+	err := ui.Init()
 	if err != nil {
-		log.Fatalf("ERROR: %v", err)
-		os.Exit(1)
+		panic(err)
 	}
+	defer ui.Close()
 
-	sigch := make(chan os.Signal)
-	keych := make(chan string)
-	waitingSortOption := false
+	statsCh := make(chan *Stats)
 
-	signal.Notify(sigch, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
-	clearScreen()
-	go StartSimpleUI(opts)
-	go listenKeyboard(keych)
+	go monitorStats(opts, statsCh)
 
-	for {
-		select {
-		case <-sigch:
-			cleanExit()
-
-		case keys := <-keych:
-			if !waitingSortOption && keys == "o\n" {
-				opts["header"] = fmt.Sprintf("\033[1;1H\033[6;1Hsort by [%s]: ", opts["sort"])
-				waitingSortOption = true
-				continue
-			}
-			if !waitingSortOption && keys == "q\n" {
-				cleanExit()
-			}
-
-			if waitingSortOption {
-				switch keys {
-				case "cid\n":
-					opts["sort"] = "cid"
-				case "subs\n":
-					opts["sort"] = "subs"
-				case "pending\n":
-					opts["sort"] = "pending"
-				case "msgs_to\n":
-					opts["sort"] = "msgs_to"
-				case "msgs_from\n":
-					opts["sort"] = "msgs_from"
-				case "bytes_to\n":
-					opts["sort"] = "bytes_to"
-				case "bytes_from\n":
-					opts["sort"] = "bytes_from"
-				}
-				waitingSortOption = false
-				opts["header"] = ""
-			}
-		}
-	}
+	StartRatesUI(opts, statsCh)
 }
 
+// clearScreen tries to ensure resetting original state of screen
 func clearScreen() {
 	fmt.Print("\033[2J\033[1;1H\033[?25l")
 }
 
 func cleanExit() {
 	clearScreen()
+	ui.Close()
 
 	// Show cursor once again
 	fmt.Print("\033[?25h")
 	os.Exit(0)
 }
 
-func listenKeyboard(keych chan string) {
-	for {
-		reader := bufio.NewReader(os.Stdin)
-		keys, _ := reader.ReadString('\n')
-		keych <- keys
-	}
+func exitWithError() {
+	ui.Close()
+	os.Exit(1)
 }
 
-func StartSimpleUI(opts map[string]interface{}) {
+// monitorStats can be ran as a goroutine and takes options
+// which can modify how to do the polling
+func monitorStats(
+	opts map[string]interface{},
+	statsCh chan *Stats,
+) {
 	var pollTime time.Time
 
 	var inMsgsDelta int64
@@ -163,51 +118,55 @@ func StartSimpleUI(opts map[string]interface{}) {
 
 	first := true
 	pollTime = time.Now()
+
 	for {
-		wg := &sync.WaitGroup{}
-		wg.Add(2)
+		// Note that delay defines the sampling rate as well
+		if val, ok := opts["delay"].(int); ok {
+			time.Sleep(time.Duration(val) * time.Second)
+		} else {
+			log.Fatalf("error: could not use %s as a refreshing interval", opts["delay"])
+			break
+		}
 
-		// Periodically poll for the varz, connz and routez
-		var varz *server.Varz
-		go func() {
-			var err error
-			defer wg.Done()
+		// Wrap collected info in a Stats struct
+		stats := &Stats{
+			Varz:  &gnatsd.Varz{},
+			Connz: &gnatsd.Connz{},
+			Rates: &Rates{},
+		}
 
+		// Get /varz
+		{
 			result, err := Request("/varz", opts)
 			if err != nil {
-				log.Fatalf("Could not get /varz: %v", err)
+				fmt.Fprintf(os.Stderr, "could not get /varz: %v", err)
+				statsCh <- stats
+				continue
 			}
-
-			if varzVal, ok := result.(*server.Varz); ok {
-				varz = varzVal
+			if varz, ok := result.(*gnatsd.Varz); ok {
+				stats.Varz = varz
 			}
-		}()
+		}
 
-		var connz *server.Connz
-		go func() {
-			var err error
-			defer wg.Done()
-
+		// Get /connz
+		{
 			result, err := Request("/connz", opts)
 			if err != nil {
-				log.Fatalf("Could not get /connz: %v", err)
+				fmt.Fprintf(os.Stderr, "could not get /connz: %v", err)
+				statsCh <- stats
+				continue
 			}
 
-			if connzVal, ok := result.(*server.Connz); ok {
-				connz = connzVal
+			if connz, ok := result.(*gnatsd.Connz); ok {
+				stats.Connz = connz
 			}
-		}()
-		wg.Wait()
-
-		cpu := varz.CPU
-		numConns := connz.NumConns
-		memVal := varz.Mem
+		}
 
 		// Periodic snapshot to get per sec metrics
-		inMsgsVal := varz.InMsgs
-		outMsgsVal := varz.OutMsgs
-		inBytesVal := varz.InBytes
-		outBytesVal := varz.OutBytes
+		inMsgsVal := stats.Varz.InMsgs
+		outMsgsVal := stats.Varz.OutMsgs
+		inBytesVal := stats.Varz.InBytes
+		outBytesVal := stats.Varz.OutBytes
 
 		inMsgsDelta = inMsgsVal - inMsgsLastVal
 		outMsgsDelta = outMsgsVal - outMsgsLastVal
@@ -224,75 +183,220 @@ func StartSimpleUI(opts map[string]interface{}) {
 		pollTime = now
 
 		// Calculate rates but the first time
-		if !first {
+		if first {
+			first = false
+		} else {
 			inMsgsRate = float64(inMsgsDelta) / tdelta.Seconds()
 			outMsgsRate = float64(outMsgsDelta) / tdelta.Seconds()
 			inBytesRate = float64(inBytesDelta) / tdelta.Seconds()
 			outBytesRate = float64(outBytesDelta) / tdelta.Seconds()
 		}
 
-		mem := Psize(memVal)
-		inMsgs := Psize(inMsgsVal)
-		outMsgs := Psize(outMsgsVal)
-		inBytes := Psize(inBytesVal)
-		outBytes := Psize(outBytesVal)
-
-		info := "\nServer:\n  Load: CPU: %.1f%%  Memory: %s\n"
-		info += "  In:   Msgs: %s  Bytes: %s  Msgs/Sec: %.1f  Bytes/Sec: %.1f\n"
-		info += "  Out:  Msgs: %s  Bytes: %s  Msgs/Sec: %.1f  Bytes/Sec: %.1f"
-
-		text := fmt.Sprintf(info, cpu, mem,
-			inMsgs, inBytes, inMsgsRate, inBytesRate,
-			outMsgs, outBytes, outMsgsRate, outBytesRate)
-		text += fmt.Sprintf("\n\nConnections: %d\n", numConns)
-
-		connHeader := "  %-20s %-8s %-6s  %-10s  %-10s  %-10s  %-10s  %-10s  %-10s  %-10s\n"
-
-		connRows := fmt.Sprintf(connHeader, "HOST", "CID", "SUBS", "PENDING",
-			"MSGS_TO", "MSGS_FROM", "BYTES_TO", "BYTES_FROM",
-			"LANG", "VERSION")
-		text += connRows
-		connValues := "  %-20s %-8d %-6d  %-10d  %-10s  %-10s  %-10s  %-10s  %-10s  %-10s\n"
-
-		switch opts["sort"] {
-		case "cid":
-			sort.Sort(ByCid(connz.Conns))
-		case "subs":
-			sort.Sort(sort.Reverse(BySubs(connz.Conns)))
-		case "pending":
-			sort.Sort(sort.Reverse(ByPending(connz.Conns)))
-		case "msgs_to":
-			sort.Sort(sort.Reverse(ByMsgsTo(connz.Conns)))
-		case "msgs_from":
-			sort.Sort(sort.Reverse(ByMsgsFrom(connz.Conns)))
-		case "bytes_to":
-			sort.Sort(sort.Reverse(ByBytesTo(connz.Conns)))
-		case "bytes_from":
-			sort.Sort(sort.Reverse(ByBytesFrom(connz.Conns)))
+		stats.Rates = &Rates{
+			InMsgsRate:   inMsgsRate,
+			OutMsgsRate:  outMsgsRate,
+			InBytesRate:  inBytesRate,
+			OutBytesRate: outBytesRate,
 		}
 
-		for _, conn := range connz.Conns {
-			host := fmt.Sprintf("%s:%d", conn.IP, conn.Port)
-			connLine := fmt.Sprintf(connValues, host, conn.Cid, conn.NumSubs, conn.Pending,
-				Psize(conn.OutMsgs), Psize(conn.InMsgs), Psize(conn.OutBytes), Psize(conn.InBytes),
-				conn.Lang, conn.Version)
-			text += connLine
+		// Send update
+		statsCh <- stats
+	}
+}
+
+// generateParagraph takes an options map and latest Stats
+// then returns a formatted paragraph ready to be rendered
+func generateParagraph(
+	opts map[string]interface{},
+	stats *Stats,
+) string {
+
+	cpu := stats.Varz.CPU
+	memVal := stats.Varz.Mem
+	uptime := stats.Varz.Uptime
+	numConns := stats.Connz.NumConns
+	inMsgsVal := stats.Varz.InMsgs
+	outMsgsVal := stats.Varz.OutMsgs
+	inBytesVal := stats.Varz.InBytes
+	outBytesVal := stats.Varz.OutBytes
+	slowConsumers := stats.Varz.SlowConsumers
+	inMsgsRate := stats.Rates.InMsgsRate
+	outMsgsRate := stats.Rates.OutMsgsRate
+	inBytesRate := stats.Rates.InBytesRate
+	outBytesRate := stats.Rates.OutBytesRate
+
+	var serverVersion string
+	if stats.Varz.Info != nil {
+		serverVersion = stats.Varz.Info.Version
+	}
+
+	mem := Psize(memVal)
+	inMsgs := Psize(inMsgsVal)
+	outMsgs := Psize(outMsgsVal)
+	inBytes := Psize(inBytesVal)
+	outBytes := Psize(outBytesVal)
+
+	info := "gnatsd version %s (uptime: %s)"
+	info += "\nServer:\n  Load: CPU: %.1f%%   Memory: %s   Slow Consumers: %d\n"
+	info += "  In:   Msgs: %s  Bytes: %s  Msgs/Sec: %.1f  Bytes/Sec: %.1f\n"
+	info += "  Out:  Msgs: %s  Bytes: %s  Msgs/Sec: %.1f  Bytes/Sec: %.1f"
+
+	text := fmt.Sprintf(info, serverVersion, uptime,
+		cpu, mem, slowConsumers,
+		inMsgs, inBytes, inMsgsRate, inBytesRate,
+		outMsgs, outBytes, outMsgsRate, outBytesRate)
+	text += fmt.Sprintf("\n\nConnections: %d\n", numConns)
+
+	connHeader := "  %-20s %-8s %-6s  %-10s  %-10s  %-10s  %-10s  %-10s  %-7s  %-7s\n"
+
+	connRows := fmt.Sprintf(connHeader, "HOST", "CID", "SUBS", "PENDING",
+		"MSGS_TO", "MSGS_FROM", "BYTES_TO", "BYTES_FROM",
+		"LANG", "VERSION")
+	text += connRows
+	connValues := "  %-20s %-8d %-6d  %-10d  %-10s  %-10s  %-10s  %-10s  %-7s  %-7s\n"
+
+	switch opts["sort"] {
+	case SortByCid:
+		sort.Sort(ByCid(stats.Connz.Conns))
+	case SortBySubs:
+		sort.Sort(sort.Reverse(BySubs(stats.Connz.Conns)))
+	case SortByOutMsgs:
+		sort.Sort(sort.Reverse(ByMsgsTo(stats.Connz.Conns)))
+	case SortByInMsgs:
+		sort.Sort(sort.Reverse(ByMsgsFrom(stats.Connz.Conns)))
+	case SortByOutBytes:
+		sort.Sort(sort.Reverse(ByBytesTo(stats.Connz.Conns)))
+	case SortByInBytes:
+		sort.Sort(sort.Reverse(ByBytesFrom(stats.Connz.Conns)))
+	}
+
+	for _, conn := range stats.Connz.Conns {
+		host := fmt.Sprintf("%s:%d", conn.IP, conn.Port)
+		connLine := fmt.Sprintf(connValues, host, conn.Cid, conn.NumSubs, conn.Pending,
+			Psize(conn.OutMsgs), Psize(conn.InMsgs), Psize(conn.OutBytes), Psize(conn.InBytes),
+			conn.Lang, conn.Version)
+		text += connLine
+	}
+
+	return text
+}
+
+// StartRatesUI periodically refreshes the state of the screen
+func StartRatesUI(
+	opts map[string]interface{},
+	statsCh chan *Stats,
+) {
+
+	cleanStats := &Stats{
+		Varz:  &gnatsd.Varz{},
+		Connz: &gnatsd.Connz{},
+		Rates: &Rates{},
+	}
+	text := generateParagraph(opts, cleanStats)
+	par := ui.NewPar(text)
+	par.Height = ui.TermHeight()
+	par.Width = ui.TermWidth()
+	par.HasBorder = false
+
+	done := make(chan struct{})
+	redraw := make(chan bool)
+
+	update := func() {
+		for {
+			stats := <-statsCh
+			text = generateParagraph(opts, stats)
+			par.Text = text
+
+			redraw <- true
 		}
-		fmt.Print(text)
+		done <- struct{}{}
+	}
 
-		// Move cursor to sort by options position
-		fmt.Print(opts["header"])
-
-		if first {
-			first = false
+	waitingSortOption := false
+	sortOptionBuf := ""
+	refreshSortHeader := func() {
+		// Need to mask what was typed before
+		clrline := "\033[1;1H\033[6;1H                  "
+		for i := 0; i < len(opts["sort"].(gnatsd.SortOpt)); i++ {
+			clrline += " "
 		}
+		clrline += "  "
+		for i := 0; i < len(sortOptionBuf); i++ {
+			clrline += " "
+		}
+		fmt.Printf(clrline)
+	}
 
-		if val, ok := opts["delay"].(int); ok {
-			time.Sleep(time.Duration(val) * time.Second)
-			clearScreen()
-		} else {
-			log.Fatalf("error: could not use %s as a refreshing interval", opts["delay"])
-			break
+	evt := ui.EventCh()
+	ui.Render(par)
+	go update()
+
+	for {
+		select {
+		case e := <-evt:
+
+			if waitingSortOption {
+
+				if e.Type == ui.EventKey && e.Key == ui.KeyEnter {
+
+					sortOpt := gnatsd.SortOpt(sortOptionBuf)
+					switch sortOpt {
+					case SortByCid, SortBySubs, SortByOutMsgs, SortByInMsgs, SortByOutBytes, SortByInBytes:
+						opts["sort"] = sortOpt
+					default:
+						go func() {
+							// Has to be at least of the same length as sort by header
+							emptyPadding := ""
+							if len(sortOptionBuf) < 5 {
+								emptyPadding = "     "
+							}
+							fmt.Printf("\033[1;1H\033[6;1Hinvalid order: %s%s", emptyPadding, sortOptionBuf)
+							waitingSortOption = false
+							time.Sleep(1 * time.Second)
+							refreshSortHeader()
+							sortOptionBuf = ""
+						}()
+						continue
+					}
+
+					refreshSortHeader()
+					waitingSortOption = false
+					sortOptionBuf = ""
+					continue
+				}
+
+				// Handle backspace
+				if e.Type == ui.EventKey && len(sortOptionBuf) > 0 && (e.Key == ui.KeyBackspace || e.Key == ui.KeyBackspace2) {
+					sortOptionBuf = sortOptionBuf[:len(sortOptionBuf)-1]
+					refreshSortHeader()
+				} else {
+					sortOptionBuf += string(e.Ch)
+				}
+				fmt.Printf("\033[1;1H\033[6;1Hsort by [%s]: %s", opts["sort"], sortOptionBuf)
+			}
+
+			if e.Type == ui.EventKey && e.Ch == 'q' {
+				cleanExit()
+			}
+
+			if e.Type == ui.EventKey && e.Ch == 'o' {
+				fmt.Printf("\033[1;1H\033[6;1Hsort by [%s]:", opts["sort"])
+				waitingSortOption = true
+			}
+
+			if e.Type == ui.EventKey && e.Key == ui.KeySpace {
+				// Not implemented
+			}
+
+			if e.Type == ui.EventResize {
+				ui.Body.Align()
+				go func() { redraw <- true }()
+			}
+
+		case <-done:
+			return
+		case <-redraw:
+			ui.Render(par)
 		}
 	}
 }

--- a/nats-top.go
+++ b/nats-top.go
@@ -22,7 +22,7 @@ var (
 	conns       = flag.Int("n", 1024, "Maximum number of connections to poll.")
 	delay       = flag.Int("d", 1, "Refresh interval in seconds.")
 	sortBy      = flag.String("sort", "cid", "Value for which to sort by the connections.")
-	showVersion = flag.Bool("v", false, "Show nats-top version")
+	showVersion = flag.Bool("v", false, "Show nats-top version.")
 )
 
 func usage() {
@@ -139,7 +139,7 @@ func monitorStats(
 		{
 			result, err := Request("/varz", opts)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "could not get /varz: %v", err)
+				// fmt.Fprintf(os.Stderr, "could not get /varz: %v", err)
 				statsCh <- stats
 				continue
 			}
@@ -152,7 +152,7 @@ func monitorStats(
 		{
 			result, err := Request("/connz", opts)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "could not get /connz: %v", err)
+				// fmt.Fprintf(os.Stderr, "could not get /connz: %v", err)
 				statsCh <- stats
 				continue
 			}

--- a/nats-top.go
+++ b/nats-top.go
@@ -59,6 +59,7 @@ func main() {
 		opts["sort"] = sortOpt
 	default:
 		log.Printf("nats-top: not a valid option to sort by: %s\n", sortOpt)
+		usage()
 	}
 
 	err := ui.Init()

--- a/nats-top.go
+++ b/nats-top.go
@@ -697,6 +697,9 @@ func generateHelp() string {
 	text := `
 Command          Description
 
+space            Switch to dashboard view with graphs.
+                 Press SPACE again to return to top view.
+
 o<option>        Set primary sort key to <option>.
 
                  Option can be one of: {cid|subs|msgs_to|msgs_from|

--- a/nats-top.go
+++ b/nats-top.go
@@ -138,27 +138,20 @@ func monitorStats(
 		// Get /varz
 		{
 			result, err := Request("/varz", opts)
-			if err != nil {
-				// fmt.Fprintf(os.Stderr, "could not get /varz: %v", err)
-				statsCh <- stats
-				continue
-			}
-			if varz, ok := result.(*gnatsd.Varz); ok {
-				stats.Varz = varz
+			if err == nil {
+				if varz, ok := result.(*gnatsd.Varz); ok {
+					stats.Varz = varz
+				}
 			}
 		}
 
 		// Get /connz
 		{
 			result, err := Request("/connz", opts)
-			if err != nil {
-				// fmt.Fprintf(os.Stderr, "could not get /connz: %v", err)
-				statsCh <- stats
-				continue
-			}
-
-			if connz, ok := result.(*gnatsd.Connz); ok {
-				stats.Connz = connz
+			if err == nil {
+				if connz, ok := result.(*gnatsd.Connz); ok {
+					stats.Connz = connz
+				}
 			}
 		}
 

--- a/nats-top.go
+++ b/nats-top.go
@@ -380,11 +380,11 @@ func StartUI(
 							// Has to be at least of the same length as sort by header
 							emptyPadding := ""
 							if len(optionBuf) < 5 {
-								emptyPadding = "       "
+								emptyPadding = "   "
 							}
 							fmt.Printf("\033[1;1H\033[6;1Hinvalid order: %s%s", emptyPadding, optionBuf)
-							time.Sleep(1 * time.Second)
 							waitingSortOption = false
+							time.Sleep(1 * time.Second)
 							refreshOptionHeader()
 							optionBuf = ""
 						}()

--- a/readme.md
+++ b/readme.md
@@ -25,7 +25,7 @@ Connections: 4
 
 ## Demo
 
-[![asciicast](https://asciinema.org/a/6xgidw31a47b3uwrg0uim6083.png)](https://asciinema.org/a/6xgidw31a47b3uwrg0uim6083)
+[![asciicast](https://asciinema.org/a/aayxym1taisg8s9wba5lzdz55.png)](https://asciinema.org/a/aayxym1taisg8s9wba5lzdz55)
 
 ## Install
 
@@ -77,6 +77,10 @@ While in top view, it is possible to use the following commands:
   Note that if used in conjunction with sort, the server would respect
   both options enabling queries like _connection with largest number of subscriptions_:
   `nats-top -n 1 -sort subs`
+
+- **?**
+
+  Show help message with options.
 
 - **q**
 

--- a/readme.md
+++ b/readme.md
@@ -61,9 +61,9 @@ nats-top [-s server] [-m monitor] [-n num_connections] [-d delay_in_secs] [-sort
 
 After running `nats-top`, it is possible to use the following commands:
 
-- **o <option>**
+- **o [option]**
 
-  Set primary sort key to **<option>**:
+  Set primary sort key to **[option]**:
 
   Keyname may be one of: **{cid, subs, msgs_to, msgs_from, bytes_to, bytes_from}**
 

--- a/readme.md
+++ b/readme.md
@@ -68,3 +68,12 @@ After running `nats-top`, it is possible to use the following commands:
   Keyname may be one of: **{cid, subs, msgs_to, msgs_from, bytes_to, bytes_from}**
 
   This can be set in the command line too, e.g. `nats-top -sort bytes_to`
+
+- **n <limit>**
+
+  Set sample size of connections to request from the server.
+
+  This can be set in the command line as well: `nats-top -n 1`
+  Note that if used in conjunction with sort, the server would respect
+  both options enabling queries like _connection with largest number of subscriptions_:
+  `nats-top -n 1 -sort subs`

--- a/readme.md
+++ b/readme.md
@@ -77,3 +77,7 @@ While in top view, it is possible to use the following commands:
   Note that if used in conjunction with sort, the server would respect
   both options enabling queries like _connection with largest number of subscriptions_:
   `nats-top -n 1 -sort subs`
+
+- **q**
+
+  Quit nats-top.

--- a/readme.md
+++ b/readme.md
@@ -59,7 +59,7 @@ nats-top [-s server] [-m monitor] [-n num_connections] [-d delay_in_secs] [-sort
 
 ## Commands
 
-After running `nats-top`, it is possible to use the following commands:
+While in top view, it is possible to use the following commands:
 
 - **o [option]**
 

--- a/readme.md
+++ b/readme.md
@@ -69,7 +69,7 @@ After running `nats-top`, it is possible to use the following commands:
 
   This can be set in the command line too, e.g. `nats-top -sort bytes_to`
 
-- **n <limit>**
+- **n [limit]**
 
   Set sample size of connections to request from the server.
 

--- a/readme.md
+++ b/readme.md
@@ -25,10 +25,6 @@ Connections: 4
 
 ![Graphs](https://cloud.githubusercontent.com/assets/26195/9292536/ad64c034-43b5-11e5-8e34-1eb3d3521bc9.png)
 
-## Demo
-
-[![asciicast](https://asciinema.org/a/aayxym1taisg8s9wba5lzdz55.png)](https://asciinema.org/a/aayxym1taisg8s9wba5lzdz55)
-
 ## Install
 
 Can be installed via `go get`:
@@ -62,10 +58,6 @@ nats-top [-s server] [-m monitor] [-n num_connections] [-d delay_in_secs] [-sort
 ## Commands
 
 While in top view, it is possible to use the following commands:
-
-- **[space]**
-
-  Switch to dashboard view with graphs.  Press SPACE again to return to top view.
 
 - **o [option]**
 

--- a/readme.md
+++ b/readme.md
@@ -23,6 +23,8 @@ Connections: 4
   127.0.0.1:56151      5        8       0           11.4K       11.5K       1014.6K     1.0M        go       1.1.0
 ```
 
+![Graphs](https://cloud.githubusercontent.com/assets/26195/9292536/ad64c034-43b5-11e5-8e34-1eb3d3521bc9.png)
+
 ## Demo
 
 [![asciicast](https://asciinema.org/a/aayxym1taisg8s9wba5lzdz55.png)](https://asciinema.org/a/aayxym1taisg8s9wba5lzdz55)
@@ -60,6 +62,10 @@ nats-top [-s server] [-m monitor] [-n num_connections] [-d delay_in_secs] [-sort
 ## Commands
 
 While in top view, it is possible to use the following commands:
+
+- **[space]**
+
+  Switch to dashboard view with graphs.  Press SPACE again to return to top view.
 
 - **o [option]**
 

--- a/readme.md
+++ b/readme.md
@@ -1,24 +1,66 @@
 # nats-top
 
-Top like program monitor for gnatsd written in Go.
+[![MIT License](http://img.shields.io/badge/license-MIT-blue.svg?style=flat-square)][license]
+
+[license]: https://github.com/nats-io/nats-top/blob/master/LICENSE
+
+`nats-top` is a `top`-like tool for monitoring gnatsd servers.
 
 ```sh
-go get github.com/nats-io/nats-top
+$ nats-top
 
-Usage: nats-top [-s server] [-m monitor] [-n num_connections] [-d delay_secs] [--sort by]
-```
-
-Example Output:
-
-```sh
+gnatsd version 0.6.4 (uptime: 31m42s)
 Server:
-  Load: CPU: 0.0% Memory: 5.5M
-  In:   Msgs: 2.2K  Bytes: 8.0K  Msgs/Sec: 1.0  Bytes/Sec: 1.0
-  Out:  Msgs: 2.2K  Bytes: 8.0K  Msgs/Sec: 1.0  Bytes/Sec: 1.0
+  Load: CPU: 0.8%   Memory: 5.9M  Slow Consumers: 0
+  In:   Msgs: 34.2K  Bytes: 3.0M  Msgs/Sec: 37.9  Bytes/Sec: 3389.7
+  Out:  Msgs: 68.3K  Bytes: 6.0M  Msgs/Sec: 75.8  Bytes/Sec: 6779.4
 
-Connections: 1
-  HOST                 CID      SUBS    PENDING     MSGS_TO     MSGS_FROM   BYTES_TO    BYTES_FROM  LANG  VERSION
-  127.0.0.1:56358      4        1       0           1.2K        1.2K        4.5K        4.5K
+Connections: 4
+  HOST                 CID      SUBS    PENDING     MSGS_TO     MSGS_FROM   BYTES_TO    BYTES_FROM  LANG     VERSION
+  127.0.0.1:56134      2        5       0           11.6K       11.6K       1.1M        905.1K      go       1.1.0
+  127.0.1.1:56138      3        1       0           34.2K       0           3.0M        0           go       1.1.0
+  127.0.0.1:56144      4        5       0           11.2K       11.1K       873.5K      1.1M        go       1.1.0
+  127.0.0.1:56151      5        8       0           11.4K       11.5K       1014.6K     1.0M        go       1.1.0
 ```
 
-It also supports ordering during the nats-top session by pressing `o` then `ENTER`.
+## Demo
+
+[![asciicast](https://asciinema.org/a/6xgidw31a47b3uwrg0uim6083.png)](https://asciinema.org/a/6xgidw31a47b3uwrg0uim6083)
+
+## Install
+
+Can be installed via `go get`:
+
+```sh
+go get -d github.com/nats-io/nats-top
+```
+
+## Usage
+
+```
+nats-top [-s server] [-m monitor] [-n num_connections] [-d delay_in_secs] [-sort by]
+```
+
+- `-m monitor`
+
+  Monitoring http port from gnatsd.
+
+- `-m num_connections`
+
+  Limit the connections requested to the server.
+
+- `-d delay_in_secs`
+
+  Screen refresh interval (minimum 1 second).
+
+## Commands
+
+After running `nats-top`, it is possible to use the following commands:
+
+- o <option>
+
+  Set primary sort key to <key>:
+
+  Keyname may be one of: {cid, subs, msgs_to, msgs_from, bytes_to, bytes_from}
+
+  This can be set in the command line too, e.g. `nats-top -sort bytes_to`.

--- a/readme.md
+++ b/readme.md
@@ -45,22 +45,26 @@ nats-top [-s server] [-m monitor] [-n num_connections] [-d delay_in_secs] [-sort
 
   Monitoring http port from gnatsd.
 
-- `-m num_connections`
+- `-n num_connections`
 
-  Limit the connections requested to the server.
+  Limit the connections requested to the server (default: `1024`)
 
 - `-d delay_in_secs`
 
-  Screen refresh interval (minimum 1 second).
+  Screen refresh interval (default: 1 second).
+
+- `-sort by `
+
+  Field to use for sorting the connections.
 
 ## Commands
 
 After running `nats-top`, it is possible to use the following commands:
 
-- o <option>
+- **o <option>**
 
-  Set primary sort key to <key>:
+  Set primary sort key to **<option>**:
 
-  Keyname may be one of: {cid, subs, msgs_to, msgs_from, bytes_to, bytes_from}
+  Keyname may be one of: **{cid, subs, msgs_to, msgs_from, bytes_to, bytes_from}**
 
-  This can be set in the command line too, e.g. `nats-top -sort bytes_to`.
+  This can be set in the command line too, e.g. `nats-top -sort bytes_to`

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ Connections: 4
 Can be installed via `go get`:
 
 ```sh
-go get -d github.com/nats-io/nats-top
+go get github.com/nats-io/nats-top
 ```
 
 ## Usage

--- a/test/toputils_test.go
+++ b/test/toputils_test.go
@@ -1,25 +1,38 @@
 package test
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/nats-io/gnatsd/server"
-	natstest "github.com/nats-io/gnatsd/test"
+	gnatsd "github.com/nats-io/gnatsd/test"
 	. "github.com/nats-io/nats-top/util"
 )
 
+// Borrowed from gnatsd tests
+const GNATSD_PORT = 11422
+
+func runMonitorServer(monitorPort int) *server.Server {
+	resetPreviousHTTPConnections()
+	opts := gnatsd.DefaultTestOptions
+	opts.Host = "127.0.0.1"
+	opts.Port = GNATSD_PORT
+	opts.HTTPPort = monitorPort
+
+	return gnatsd.RunServer(&opts)
+}
+
+func resetPreviousHTTPConnections() {
+	http.DefaultTransport = &http.Transport{}
+}
+
 func TestFetchingStatz(t *testing.T) {
 	params := make(map[string]interface{})
-	natsHttpPort := 8222
-
 	params["host"] = "127.0.0.1"
-	params["port"] = natsHttpPort
+	params["port"] = server.DEFAULT_HTTP_PORT
 
-	opts := natstest.DefaultTestOptions
-	opts.Port = 8888
-	opts.HTTPPort = natsHttpPort
-
-	s := natstest.RunServer(&opts)
+	s := runMonitorServer(server.DEFAULT_HTTP_PORT)
+	defer s.Shutdown()
 
 	// Getting Varz
 	var varz *server.Varz

--- a/util/toputils.go
+++ b/util/toputils.go
@@ -9,91 +9,8 @@ import (
 	"github.com/nats-io/gnatsd/server"
 )
 
-type ByCid []*server.ConnInfo
-
-func (d ByCid) Len() int {
-	return len(d)
-}
-func (d ByCid) Swap(i, j int) {
-	d[i], d[j] = d[j], d[i]
-}
-func (d ByCid) Less(i, j int) bool {
-	return d[i].Cid < d[j].Cid
-}
-
-type BySubs []*server.ConnInfo
-
-func (d BySubs) Len() int {
-	return len(d)
-}
-func (d BySubs) Swap(i, j int) {
-	d[i], d[j] = d[j], d[i]
-}
-func (d BySubs) Less(i, j int) bool {
-	return d[i].NumSubs < d[j].NumSubs
-}
-
-type ByPending []*server.ConnInfo
-
-func (d ByPending) Len() int {
-	return len(d)
-}
-func (d ByPending) Swap(i, j int) {
-	d[i], d[j] = d[j], d[i]
-}
-func (d ByPending) Less(i, j int) bool {
-	return d[i].Pending < d[j].Pending
-}
-
-type ByMsgsTo []*server.ConnInfo
-
-func (d ByMsgsTo) Len() int {
-	return len(d)
-}
-func (d ByMsgsTo) Swap(i, j int) {
-	d[i], d[j] = d[j], d[i]
-}
-func (d ByMsgsTo) Less(i, j int) bool {
-	return d[i].OutMsgs < d[j].OutMsgs
-}
-
-type ByMsgsFrom []*server.ConnInfo
-
-func (d ByMsgsFrom) Len() int {
-	return len(d)
-}
-func (d ByMsgsFrom) Swap(i, j int) {
-	d[i], d[j] = d[j], d[i]
-}
-func (d ByMsgsFrom) Less(i, j int) bool {
-	return d[i].InMsgs < d[j].InMsgs
-}
-
-type ByBytesTo []*server.ConnInfo
-
-func (d ByBytesTo) Len() int {
-	return len(d)
-}
-func (d ByBytesTo) Swap(i, j int) {
-	d[i], d[j] = d[j], d[i]
-}
-func (d ByBytesTo) Less(i, j int) bool {
-	return d[i].OutBytes < d[j].OutBytes
-}
-
-type ByBytesFrom []*server.ConnInfo
-
-func (d ByBytesFrom) Len() int {
-	return len(d)
-}
-func (d ByBytesFrom) Swap(i, j int) {
-	d[i], d[j] = d[j], d[i]
-}
-func (d ByBytesFrom) Less(i, j int) bool {
-	return d[i].InBytes < d[j].InBytes
-}
-
-// Takes a path and options, then returns a serialized connz, varz, or routez response
+// Request takes a path and options, and returns a Stats struct
+// with with either connz or varz
 func Request(path string, opts map[string]interface{}) (interface{}, error) {
 	var statz interface{}
 	uri := fmt.Sprintf("http://%s:%d%s", opts["host"], opts["port"], path)
@@ -103,30 +20,31 @@ func Request(path string, opts map[string]interface{}) (interface{}, error) {
 		statz = &server.Varz{}
 	case "/connz":
 		statz = &server.Connz{}
-		uri += fmt.Sprintf("?limit=%d&s=%s", opts["conns"], opts["sort"])
+		uri += fmt.Sprintf("?limit=%d&sort=%s", opts["conns"], opts["sort"])
 	default:
 		return nil, fmt.Errorf("invalid path '%s' for stats server", path)
 	}
 
 	resp, err := http.Get(uri)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching %s: %v", path, err)
+		return nil, fmt.Errorf("could not get stats from server: %v\n", err)
 	}
 
+	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("error reading stat from upstream: %s", err)
+		return nil, fmt.Errorf("could not read response body: %v\n", err)
 	}
 
 	err = json.Unmarshal(body, &statz)
 	if err != nil {
-		return nil, fmt.Errorf("error unmarshaling json: %v", err)
+		return nil, fmt.Errorf("could not unmarshal json: %v\n", err)
 	}
 
 	return statz, nil
 }
 
-// Takes a float and returns a human readable string
+// Psize takes a float and returns a human readable string
 func Psize(s int64) string {
 	size := float64(s)
 

--- a/util/types.go
+++ b/util/types.go
@@ -1,0 +1,111 @@
+package toputils
+
+import (
+	"github.com/nats-io/gnatsd/server"
+)
+
+type Stats struct {
+	Varz  *server.Varz
+	Connz *server.Connz
+	Rates *Rates
+}
+
+type Rates struct {
+	InMsgsRate   float64
+	OutMsgsRate  float64
+	InBytesRate  float64
+	OutBytesRate float64
+}
+
+const (
+	SortByCid      server.SortOpt = "cid"
+	SortBySubs                    = "subs"
+	SortByOutMsgs                 = "msgs_to"
+	SortByInMsgs                  = "msgs_from"
+	SortByOutBytes                = "bytes_to"
+	SortByInBytes                 = "bytes_from"
+)
+
+type ByCid []*server.ConnInfo
+
+func (d ByCid) Len() int {
+	return len(d)
+}
+func (d ByCid) Swap(i, j int) {
+	d[i], d[j] = d[j], d[i]
+}
+func (d ByCid) Less(i, j int) bool {
+	return d[i].Cid < d[j].Cid
+}
+
+type BySubs []*server.ConnInfo
+
+func (d BySubs) Len() int {
+	return len(d)
+}
+func (d BySubs) Swap(i, j int) {
+	d[i], d[j] = d[j], d[i]
+}
+func (d BySubs) Less(i, j int) bool {
+	return d[i].NumSubs < d[j].NumSubs
+}
+
+type ByPending []*server.ConnInfo
+
+func (d ByPending) Len() int {
+	return len(d)
+}
+func (d ByPending) Swap(i, j int) {
+	d[i], d[j] = d[j], d[i]
+}
+func (d ByPending) Less(i, j int) bool {
+	return d[i].Pending < d[j].Pending
+}
+
+type ByMsgsTo []*server.ConnInfo
+
+func (d ByMsgsTo) Len() int {
+	return len(d)
+}
+func (d ByMsgsTo) Swap(i, j int) {
+	d[i], d[j] = d[j], d[i]
+}
+func (d ByMsgsTo) Less(i, j int) bool {
+	return d[i].OutMsgs < d[j].OutMsgs
+}
+
+type ByMsgsFrom []*server.ConnInfo
+
+func (d ByMsgsFrom) Len() int {
+	return len(d)
+}
+func (d ByMsgsFrom) Swap(i, j int) {
+	d[i], d[j] = d[j], d[i]
+}
+func (d ByMsgsFrom) Less(i, j int) bool {
+	return d[i].InMsgs < d[j].InMsgs
+}
+
+type ByBytesTo []*server.ConnInfo
+
+func (d ByBytesTo) Len() int {
+	return len(d)
+}
+func (d ByBytesTo) Swap(i, j int) {
+	d[i], d[j] = d[j], d[i]
+}
+func (d ByBytesTo) Less(i, j int) bool {
+	return d[i].OutBytes < d[j].OutBytes
+}
+
+type ByBytesFrom []*server.ConnInfo
+
+func (d ByBytesFrom) Len() int {
+	return len(d)
+}
+func (d ByBytesFrom) Swap(i, j int) {
+	d[i], d[j] = d[j], d[i]
+}
+func (d ByBytesFrom) Less(i, j int) bool {
+	return d[i].InBytes < d[j].InBytes
+}


### PR DESCRIPTION
This is a rewrite of the nats-top tool using the gizak/termui framework.
It also adopts the latest changes in gnatsd monitor server to make it possible to query the server using `limit` and `sort` options and displaying slow consumers:

```
gnatsd version 0.6.4 (uptime: 31m42s)
Server:
  Load: CPU: 0.8%   Memory: 5.9M  Slow Consumers: 0
  In:   Msgs: 34.2K  Bytes: 3.0M  Msgs/Sec: 37.9  Bytes/Sec: 3389.7
  Out:  Msgs: 68.3K  Bytes: 6.0M  Msgs/Sec: 75.8  Bytes/Sec: 6779.4

Connections: 4
  HOST                 CID      SUBS    PENDING     MSGS_TO     MSGS_FROM   BYTES_TO    BYTES_FROM  LANG     VERSION
  127.0.0.1:56134      2        5       0           11.6K       11.6K       1.1M        905.1K      go       1.1.0
  127.0.1.1:56138      3        1       0           34.2K       0           3.0M        0           go       1.1.0
  127.0.0.1:56144      4        5       0           11.2K       11.1K       873.5K      1.1M        go       1.1.0
  127.0.0.1:56151      5        8       0           11.4K       11.5K       1014.6K     1.0M        go       1.1.0
```

Help message with more info on the feature set:

```
- o [option]

Set primary sort key to [option]:

Keyname may be one of: {cid, subs, msgs_to, msgs_from, bytes_to, bytes_from}

This can be set in the command line too, e.g. nats-top -sort bytes_to

- n [limit]

Set sample size of connections to request from the server.

This can be set in the command line as well: nats-top -n 1 Note that
if used in conjunction with sort, the server would respect both
options enabling queries like connection with largest number of
subscriptions: nats-top -n 1 -sort subs

- ?

Show help message with options.

- q

Quit nats-top.
```
