### PR TITLE
Display subscriptions from a connection

### DIFF
--- a/nats-top.go
+++ b/nats-top.go
@@ -366,7 +366,7 @@ func StartUI(
 				cleanExit()
 			}
 
-			if e.Type == ui.EventKey && e.Ch == 's' {
+			if e.Type == ui.EventKey && e.Ch == 's' && !(waitingLimitOption || waitingSortOption) {
 				if displaySubscriptions {
 					displaySubscriptions = false
 					opts["subs"] = false

--- a/readme.md
+++ b/readme.md
@@ -16,11 +16,11 @@ Server:
   Out:  Msgs: 68.3K  Bytes: 6.0M  Msgs/Sec: 75.8  Bytes/Sec: 6779.4
 
 Connections: 4
-  HOST                 CID      SUBS    PENDING     MSGS_TO     MSGS_FROM   BYTES_TO    BYTES_FROM  LANG     VERSION
-  127.0.0.1:56134      2        5       0           11.6K       11.6K       1.1M        905.1K      go       1.1.0
-  127.0.1.1:56138      3        1       0           34.2K       0           3.0M        0           go       1.1.0
-  127.0.0.1:56144      4        5       0           11.2K       11.1K       873.5K      1.1M        go       1.1.0
-  127.0.0.1:56151      5        8       0           11.4K       11.5K       1014.6K     1.0M        go       1.1.0
+  HOST                 CID      SUBS    PENDING     MSGS_TO     MSGS_FROM   BYTES_TO    BYTES_FROM  LANG     VERSION SUBSCRIPTIONS
+  127.0.0.1:56134      2        5       0           11.6K       11.6K       1.1M        905.1K      go       1.1.0   foo, hello
+  127.0.1.1:56138      3        1       0           34.2K       0           3.0M        0           go       1.1.0    _INBOX.a96f3f6853616154d23d1b5072
+  127.0.0.1:56144      4        5       0           11.2K       11.1K       873.5K      1.1M        go       1.1.0   foo, hello
+  127.0.0.1:56151      5        8       0           11.4K       11.5K       1014.6K     1.0M        go       1.1.0   foo, hello
 ```
 
 ## Install
@@ -73,6 +73,10 @@ While in top view, it is possible to use the following commands:
   Note that if used in conjunction with sort, the server would respect
   both options enabling queries like _connection with largest number of subscriptions_:
   `nats-top -n 1 -sort subs`
+
+- **s**
+
+  Toggle displaying connection subscriptions.
 
 - **?**
 

--- a/util/toputils.go
+++ b/util/toputils.go
@@ -10,6 +10,8 @@ import (
 	gnatsd "github.com/nats-io/gnatsd/server"
 )
 
+const DisplaySubscriptions = 1
+
 // Request takes a path and options, and returns a Stats struct
 // with with either connz or varz
 func Request(path string, opts map[string]interface{}) (interface{}, error) {
@@ -22,6 +24,11 @@ func Request(path string, opts map[string]interface{}) (interface{}, error) {
 	case "/connz":
 		statz = &gnatsd.Connz{}
 		uri += fmt.Sprintf("?limit=%d&sort=%s", opts["conns"], opts["sort"])
+		if displaySubs, ok := opts["subs"]; ok {
+			if displaySubs.(bool) {
+				uri += fmt.Sprintf("&subs=%d", DisplaySubscriptions)
+			}
+		}
 	default:
 		return nil, fmt.Errorf("invalid path '%s' for stats server", path)
 	}


### PR DESCRIPTION
With this change, upon pressing `s`, a  `SUBSCRIPTIONS` column would appear showing what are the subjects that the connection is subscribed to:

```
$ nats-top

gnatsd version 0.6.4 (uptime: 31m42s)
Server:
  Load: CPU: 0.8%   Memory: 5.9M  Slow Consumers: 0
  In:   Msgs: 34.2K  Bytes: 3.0M  Msgs/Sec: 37.9  Bytes/Sec: 3389.7
  Out:  Msgs: 68.3K  Bytes: 6.0M  Msgs/Sec: 75.8  Bytes/Sec: 6779.4

Connections: 4
  HOST                 CID      SUBS    PENDING     MSGS_TO     MSGS_FROM   BYTES_TO    BYTES_FROM  LANG     VERSION SUBSCRIPTIONS
  127.0.0.1:56134      2        5       0           11.6K       11.6K       1.1M        905.1K      go       1.1.0   foo, hello
  127.0.1.1:56138      3        1       0           34.2K       0           3.0M        0           go       1.1.0    _INBOX.a96f3f6853616154d23d1b5072
  127.0.0.1:56144      4        5       0           11.2K       11.1K       873.5K      1.1M        go       1.1.0   foo, hello
  127.0.0.1:56151      5        8       0           11.4K       11.5K       1014.6K     1.0M        go       1.1.0   foo, hello
```