### PR TITLE
Rename the connections description

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ install:
 - DST=~/gopath/src/github.com/nats-io
 - mkdir -p "$DST"
 - git clone --depth=1 --quiet https://github.com/nats-io/gnatsd.git "$DST"/gnatsd
-- go get golang.org/x/tools/cmd/vet
 - go get gopkg.in/gizak/termui.v1
 - go get golang.org/x/crypto/bcrypt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.4
+- 1.6
 
 install:
 - DST=~/gopath/src/github.com/nats-io

--- a/nats-top.go
+++ b/nats-top.go
@@ -165,7 +165,7 @@ func generateParagraph(
 		cpu, mem, slowConsumers,
 		inMsgs, inBytes, inMsgsRate, inBytesRate,
 		outMsgs, outBytes, outMsgsRate, outBytesRate)
-	text += fmt.Sprintf("\n\nConnections: %d\n", numConns)
+	text += fmt.Sprintf("\n\nConnections Polled: %d\n", numConns)
 	displaySubs := engine.DisplaySubs
 
 	connHeader := "  %-20s %-8s %-15s %-6s  %-10s  %-10s  %-10s  %-10s  %-10s  %-7s  %-7s  %-7s  %-40s"


### PR DESCRIPTION
The description "Connections" becomes ambiguous when there are more than 1024 connections on a server.  Rename to indicate this is the number of connections being polled.

@wallyqs 