### PR TITLE
Rename the "Connections" description.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.5
+  - 1.6
   - tip
 
 env:
@@ -12,7 +12,6 @@ env:
 
 install:
   - go get github.com/nats-io/gnatsd
-  - go get golang.org/x/tools/cmd/vet
   - go get gopkg.in/gizak/termui.v1
   - go get golang.org/x/crypto/bcrypt
 

--- a/nats-top.go
+++ b/nats-top.go
@@ -165,7 +165,7 @@ func generateParagraph(
 		cpu, mem, slowConsumers,
 		inMsgs, inBytes, inMsgsRate, inBytesRate,
 		outMsgs, outBytes, outMsgsRate, outBytesRate)
-	text += fmt.Sprintf("\n\nConnections: %d\n", numConns)
+	text += fmt.Sprintf("\n\nConnections Polled: %d\n", numConns)
 	displaySubs := engine.DisplaySubs
 
 	connHeader := "  %-20s %-8s %-15s %-6s  %-10s  %-10s  %-10s  %-10s  %-10s  %-7s  %-7s  %-7s  %-40s"


### PR DESCRIPTION
When there are more than 1024 connections, the "Connections" description becomes ambiguous.  Rename this to indicate the value displayed represents the number of connections being polled.

* Also removed go vet (it was causing problems), and updated the go version to 1.6 in Travis.

@wallyqs for review.