### PR TITLE
Fix refreshing data when server going away, show polling error

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@
 - [X] Add name column
 - [X] Add sorting by uptime,last activity
 - [X] Support https polling
-- [ ] Align host and add padding depending on length
+- [ ] Align host and add padding depending on length (padding)
 - [ ] Enable prepend '+/-' for asc/desc sorting
 - [ ] Include /routez info
 - [ ] Upgrade gizak framework

--- a/nats-top.go
+++ b/nats-top.go
@@ -162,12 +162,12 @@ func generateParagraph(
 	inBytesRate := top.Psize(int64(stats.Rates.InBytesRate))
 	outBytesRate := top.Psize(int64(stats.Rates.OutBytesRate))
 
-	info := "NATS server version %s (uptime: %s)"
+	info := "NATS server version %s (uptime: %s) %s"
 	info += "\nServer:\n  Load: CPU:  %.1f%%  Memory: %s  Slow Consumers: %d\n"
 	info += "  In:   Msgs: %s  Bytes: %s  Msgs/Sec: %.1f  Bytes/Sec: %s\n"
 	info += "  Out:  Msgs: %s  Bytes: %s  Msgs/Sec: %.1f  Bytes/Sec: %s"
 
-	text := fmt.Sprintf(info, serverVersion, uptime,
+	text := fmt.Sprintf(info, serverVersion, uptime, stats.Error,
 		cpu, mem, slowConsumers,
 		inMsgs, inBytes, inMsgsRate, inBytesRate,
 		outMsgs, outBytes, outMsgsRate, outBytesRate)
@@ -231,6 +231,7 @@ func StartUI(engine *top.Engine) {
 		Varz:  &gnatsd.Varz{},
 		Connz: &gnatsd.Connz{},
 		Rates: &top.Rates{},
+		Error: fmt.Errorf(""),
 	}
 
 	// Show empty values on first display
@@ -268,7 +269,8 @@ func StartUI(engine *top.Engine) {
 
 	update := func() {
 		for {
-			stats := <-engine.StatsCh
+			receivedStats := <-engine.StatsCh
+			stats := receivedStats
 
 			// Update top view text
 			text = generateParagraph(engine, stats)

--- a/nats-top.go
+++ b/nats-top.go
@@ -32,11 +32,17 @@ var (
 	skipVerifyOpt = flag.Bool("k", false, "Skip verifying server certificate")
 )
 
-var usageHelp = `
+var (
+	defaultHeader       = []interface{}{"HOST", "CID", "NAME", "SUBS", "PENDING", "MSGS_TO", "MSGS_FROM", "BYTES_TO", "BYTES_FROM", "LANG", "VERSION", "UPTIME", "LAST ACTIVITY"}
+	defaultHeaderFormat = "  %-20s %-8s %-15s %-6s  %-10s  %-10s  %-10s  %-10s  %-10s  %-7s  %-7s  %-7s  %-40s"
+	defaultRowFormat    = "  %-20s %-8d %-15s %-6d  %-10s  %-10s  %-10s  %-10s  %-10s  %-7s  %-7s  %-7s  %-40s"
+
+	usageHelp = `
 usage: nats-top [-s server] [-m http_port] [-ms https_port] [-n num_connections] [-d delay_secs] [-sort by]
                 [-cert FILE] [-key FILE ][-cacert FILE] [-k]
 
 `
+)
 
 func usage() {
 	log.Fatalf(usageHelp)
@@ -168,26 +174,23 @@ func generateParagraph(
 	text += fmt.Sprintf("\n\nConnections Polled: %d\n", numConns)
 	displaySubs := engine.DisplaySubs
 
-	connHeader := "  %-20s %-8s %-15s %-6s  %-10s  %-10s  %-10s  %-10s  %-10s  %-7s  %-7s  %-7s  %-40s"
+	// TODO: Dynamic padding for columns
+	connHeader := defaultHeaderFormat
 	if displaySubs {
 		connHeader += "%13s"
 	}
 	connHeader += "\n"
 
 	var connRows string
-	var connValues string
 	if displaySubs {
-		connRows = fmt.Sprintf(connHeader, "HOST", "CID", "NAME", "SUBS", "PENDING",
-			"MSGS_TO", "MSGS_FROM", "BYTES_TO", "BYTES_FROM",
-			"LANG", "VERSION", "UPTIME", "LAST ACTIVITY", "SUBSCRIPTIONS")
+		subsHeader := append(defaultHeader, "SUBSCRIPTIONS")
+		connRows = fmt.Sprintf(connHeader, subsHeader...)
 	} else {
-		connRows = fmt.Sprintf(connHeader, "HOST", "CID", "NAME", "SUBS", "PENDING",
-			"MSGS_TO", "MSGS_FROM", "BYTES_TO", "BYTES_FROM",
-			"LANG", "VERSION", "UPTIME", "LAST ACTIVITY")
+		connRows = fmt.Sprintf(connHeader, defaultHeader...)
 	}
 	text += connRows
 
-	connValues = "  %-20s %-8d %-15s %-6d  %-10s  %-10s  %-10s  %-10s  %-10s  %-7s  %-7s  %-7s  %-40s"
+	connValues := defaultRowFormat
 	if displaySubs {
 		connValues += "%s"
 	}
@@ -197,15 +200,15 @@ func generateParagraph(
 		host := fmt.Sprintf("%s:%d", conn.IP, conn.Port)
 
 		var connLine string
+		connLineInfo := []interface{}{host, conn.Cid, conn.Name, conn.NumSubs, top.Psize(int64(conn.Pending)),
+			top.Psize(conn.OutMsgs), top.Psize(conn.InMsgs), top.Psize(conn.OutBytes), top.Psize(conn.InBytes),
+			conn.Lang, conn.Version, conn.Uptime, conn.LastActivity}
 		if displaySubs {
 			subs := strings.Join(conn.Subs, ", ")
-			connLine = fmt.Sprintf(connValues, host, conn.Cid, conn.Name, conn.NumSubs, top.Psize(int64(conn.Pending)),
-				top.Psize(conn.OutMsgs), top.Psize(conn.InMsgs), top.Psize(conn.OutBytes), top.Psize(conn.InBytes),
-				conn.Lang, conn.Version, conn.Uptime, conn.LastActivity, subs)
+			connLineInfo = append(connLineInfo, subs)
+			connLine = fmt.Sprintf(connValues, connLineInfo...)
 		} else {
-			connLine = fmt.Sprintf(connValues, host, conn.Cid, conn.Name, conn.NumSubs, top.Psize(int64(conn.Pending)),
-				top.Psize(conn.OutMsgs), top.Psize(conn.InMsgs), top.Psize(conn.OutBytes), top.Psize(conn.InBytes),
-				conn.Lang, conn.Version, conn.Uptime, conn.LastActivity)
+			connLine = fmt.Sprintf(connValues, connLineInfo...)
 		}
 
 		text += connLine


### PR DESCRIPTION
Show latest error when server goes away, and refresh screen from old data when it does.
![error-refresh](https://cloud.githubusercontent.com/assets/26195/17760332/cf8aa9d8-64b3-11e6-8ac3-29160e526842.gif)
