### PR TITLE
Add toggle for lookup DNS hostname from monitored conns

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,12 @@
 
 - [X] Show lang and version of client
-- [X] top like sort and limit
+- [X] `top` like sort and limit
 - [X] Toggle for displaying subscriptions info per conn
 - [X] Add name column
-- [X] Add sorting by uptime,last activity
+- [X] Add sorting by uptime, last activity
 - [X] Support https polling
-- [ ] Align host and add padding depending on length (padding)
-- [ ] Enable prepend '+/-' for asc/desc sorting
-- [ ] Include /routez info
+- [X] Align host and add padding depending on length (padding)
+- [X] reverse lookup from client address
+- [ ] Enable prepend `+/-` for asc/desc sorting
+- [ ] Include `/routez` info
 - [ ] Upgrade gizak framework

--- a/nats-top.go
+++ b/nats-top.go
@@ -524,6 +524,15 @@ func StartUI(engine *top.Engine) {
 				waitingSortOption = false
 			}
 
+			if e.Type == ui.EventKey && (e.Ch == 'd') && !(waitingSortOption || waitingLimitOption) {
+				switch *lookupDNS {
+				case true:
+					*lookupDNS = false
+				case false:
+					*lookupDNS = true
+				}
+			}
+
 			if e.Type == ui.EventResize {
 				ui.Body.Width = ui.TermWidth()
 				ui.Body.Align()
@@ -555,6 +564,8 @@ n<limit>         Set sample size of connections to request from the server.
                  with largest number of subscriptions': -n 1 -sort subs
 
 s                Toggle displaying connection subscriptions.
+
+d                Toggle activating DNS address lookup for clients.
 
 q                Quit nats-top.
 

--- a/readme.md
+++ b/readme.md
@@ -93,6 +93,10 @@ While in top view, it is possible to use the following commands:
 
   Toggle displaying connection subscriptions.
 
+- **d**
+
+  Toggle activating DNS address lookup for clients.
+
 - **?**
 
   Show help message with options.


### PR DESCRIPTION
Toggable via either `-lookup` in the cmd line or by pressing `d` at any time.

![nats-top-lookup](https://cloud.githubusercontent.com/assets/26195/17882797/8ac5b914-68c3-11e6-8dee-10a1df491eba.gif)
