### PR TITLE
Host column alignment fixes

### DIFF
--- a/nats-top.go
+++ b/nats-top.go
@@ -215,7 +215,7 @@ func generateParagraph(
 				hostname = addr
 			}
 		} else {
-			hostname = fmt.Sprintf("%s:%d", hostname, conn.Port)
+			hostname = fmt.Sprintf("%s:%d", conn.IP, conn.Port)
 		}
 
 		// host

--- a/nats-top.go
+++ b/nats-top.go
@@ -202,8 +202,13 @@ func generateParagraph(
 			// them for subsequent polls.
 			if addr, present := resolvedHosts[conn.IP]; !present {
 				addrs, err := net.LookupAddr(conn.IP)
-				if err == nil && len(addrs) > 0 {
+				if err == nil && len(addrs) > 0 && len(addrs[0]) > 0 {
 					hostname = addrs[0]
+					resolvedHosts[conn.IP] = hostname
+				} else {
+					// Otherwise just continue to use ip:port as resolved host
+					// can be an empty string even though there were no errors.
+					hostname = fmt.Sprintf("%s:%d", conn.IP, conn.Port)
 					resolvedHosts[conn.IP] = hostname
 				}
 			} else {


### PR DESCRIPTION
- Host looked up can have the empty value some so defaulting to `ip:port` instead on those
- Fixed alignment issues when displaying `ip:port` pairs of different lengths

![nats-top-host-alignment](https://cloud.githubusercontent.com/assets/26195/17917463/b2526474-6971-11e6-95ce-af139f7dee00.gif)
