### PR TITLE
Add Raw bytes toggle

### DIFF
--- a/nats-top.go
+++ b/nats-top.go
@@ -543,6 +543,15 @@ func StartUI(engine *top.Engine) {
 				}
 			}
 
+			if e.Type == ui.EventKey && (e.Ch == 'b') && !(waitingSortOption || waitingLimitOption) {
+				switch *displayRawBytes {
+				case true:
+					*displayRawBytes = false
+				case false:
+					*displayRawBytes = true
+				}
+			}
+
 			if e.Type == ui.EventResize {
 				ui.Body.Width = ui.TermWidth()
 				ui.Body.Align()
@@ -576,6 +585,8 @@ n<limit>         Set sample size of connections to request from the server.
 s                Toggle displaying connection subscriptions.
 
 d                Toggle activating DNS address lookup for clients.
+
+b                Toggle displaying raw bytes.
 
 q                Quit nats-top.
 

--- a/nats-top.go
+++ b/nats-top.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2015-2021 The NATS Authors
+// Copyright (c) 2015-2022 The NATS Authors
 package main
 
 import (
@@ -15,7 +15,7 @@ import (
 	ui "gopkg.in/gizak/termui.v1"
 )
 
-const version = "0.4.0"
+const version = "0.5.0"
 
 var (
 	host            = flag.String("s", "127.0.0.1", "The nats server host.")


### PR DESCRIPTION
Adds `b` short cut to toggle raw bytes mode:

```
Command          Description
                                                     
o<option>        Set primary sort key to <option>.                      
                                                                        
                 Option can be one of: {cid|subs|pending|msgs_to|msgs_from|
                 bytes_to|bytes_from|idle|last}
                                                                                                                                      
                 This can be set in the command line too with -sort flag.                                                                                     

n<limit>         Set sample size of connections to request from the server.

                 This can be set in the command line as well via -n flag.
                 Note that if used in conjunction with sort, the server
                 would respect both options allowing queries like 'connection
                 with largest number of subscriptions': -n 1 -sort subs

s                Toggle displaying connection subscriptions.

d                Toggle activating DNS address lookup for clients.

*b                Toggle displaying raw bytes.*

q                Quit nats-top.

Press any key to continue...

```