### PR TITLE
Add missing maintainer

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,6 +43,7 @@ nfpms:
   - file_name_template: '{{.ProjectName}}-{{.Tag}}-{{.Arch}}{{if .Arm}}{{.Arm}}{{end}}'
     homepage:  https://nats.io
     description: "Top(1) style utility for NATS"
+    maintainer: Waldemar Quevedo <wally@synadia.com>
     license: MIT
     vendor: "Synadia Communications, Inc"
     formats:


### PR DESCRIPTION
When updating packages on ubuntu 20.04 the following warning occurred:

```sh
dpkg: warning: parsing file '/var/lib/dpkg/status' near line 10192 package 'nats-top':
missing 'Maintainer' field
```