### PR TITLE
Change how non data numbers are displayed

### DIFF
--- a/nats-top.go
+++ b/nats-top.go
@@ -219,8 +219,8 @@ func generateParagraphPlainText(
 	}
 
 	mem := top.Psize(false, memVal) //memory is exempt from the rawbytes flag
-	inMsgs := top.Psize(*displayRawBytes, inMsgsVal)
-	outMsgs := top.Psize(*displayRawBytes, outMsgsVal)
+	inMsgs := top.Nsize(*displayRawBytes, inMsgsVal)
+	outMsgs := top.Nsize(*displayRawBytes, outMsgsVal)
 	inBytes := top.Psize(*displayRawBytes, inBytesVal)
 	outBytes := top.Psize(*displayRawBytes, outBytesVal)
 	inMsgsRate := stats.Rates.InMsgsRate
@@ -357,10 +357,10 @@ func generateParagraphPlainText(
 
 		connLineInfo = append(connLineInfo, conn.NumSubs)
 
-		connLineInfo = append(connLineInfo, top.Psize(*displayRawBytes, int64(conn.Pending)))
+		connLineInfo = append(connLineInfo, top.Nsize(*displayRawBytes, int64(conn.Pending)))
 
 		if !engine.ShowRates {
-			connLineInfo = append(connLineInfo, top.Psize(*displayRawBytes, conn.OutMsgs), top.Psize(*displayRawBytes, conn.InMsgs))
+			connLineInfo = append(connLineInfo, top.Nsize(*displayRawBytes, conn.OutMsgs), top.Nsize(*displayRawBytes, conn.InMsgs))
 			connLineInfo = append(connLineInfo, top.Psize(*displayRawBytes, conn.OutBytes), top.Psize(*displayRawBytes, conn.InBytes))
 		} else {
 			var (
@@ -376,7 +376,7 @@ func generateParagraphPlainText(
 				outBytesPerSec = crate.OutBytesRate
 				inBytesPerSec = crate.InBytesRate
 			}
-			connLineInfo = append(connLineInfo, top.Psize(*displayRawBytes, int64(outMsgsPerSec)), top.Psize(*displayRawBytes, int64(inMsgsPerSec)))
+			connLineInfo = append(connLineInfo, top.Nsize(*displayRawBytes, int64(outMsgsPerSec)), top.Nsize(*displayRawBytes, int64(inMsgsPerSec)))
 			connLineInfo = append(connLineInfo, top.Psize(*displayRawBytes, int64(outBytesPerSec)), top.Psize(*displayRawBytes, int64(inBytesPerSec)))
 		}
 
@@ -420,8 +420,8 @@ func generateParagraphCSV(
 	}
 
 	mem := top.Psize(false, memVal) //memory is exempt from the rawbytes flag
-	inMsgs := top.Psize(*displayRawBytes, inMsgsVal)
-	outMsgs := top.Psize(*displayRawBytes, outMsgsVal)
+	inMsgs := top.Nsize(*displayRawBytes, inMsgsVal)
+	outMsgs := top.Nsize(*displayRawBytes, outMsgsVal)
 	inBytes := top.Psize(*displayRawBytes, inBytesVal)
 	outBytes := top.Psize(*displayRawBytes, outBytesVal)
 	inMsgsRate := stats.Rates.InMsgsRate
@@ -519,7 +519,7 @@ func generateParagraphCSV(
 		connLineInfo = append(connLineInfo, conn.Cid)
 		connLineInfo = append(connLineInfo, conn.Name)
 		connLineInfo = append(connLineInfo, fmt.Sprintf("%d", conn.NumSubs))
-		connLineInfo = append(connLineInfo, top.Psize(*displayRawBytes, int64(conn.Pending)), top.Psize(*displayRawBytes, conn.OutMsgs), top.Psize(*displayRawBytes, conn.InMsgs))
+		connLineInfo = append(connLineInfo, top.Nsize(*displayRawBytes, int64(conn.Pending)), top.Nsize(*displayRawBytes, conn.OutMsgs), top.Nsize(*displayRawBytes, conn.InMsgs))
 		connLineInfo = append(connLineInfo, top.Psize(*displayRawBytes, conn.OutBytes), top.Psize(*displayRawBytes, conn.InBytes))
 		connLineInfo = append(connLineInfo, conn.Lang, conn.Version)
 		connLineInfo = append(connLineInfo, conn.Uptime, conn.LastActivity)

--- a/util/toputils.go
+++ b/util/toputils.go
@@ -308,7 +308,7 @@ const kibibyte = 1024
 const mebibyte = 1024 * 1024
 const gibibyte = 1024 * 1024 * 1024
 
-// Psize takes a float and returns a human readable string.
+// Psize takes a float and returns a human readable string (Used for bytes).
 func Psize(displayRawValue bool, s int64) string {
 	size := float64(s)
 
@@ -325,4 +325,27 @@ func Psize(displayRawValue bool, s int64) string {
 	}
 
 	return fmt.Sprintf("%.1fG", size/gibibyte)
+}
+
+const k = 1000
+const m = k * 1000
+const b = m * 1000
+const t = b * 1000
+
+// Nsize takes a float and returns a human readable string.
+func Nsize(displayRawValue bool, s int64) string {
+	size := float64(s)
+
+	switch {
+	case displayRawValue || size < k:
+		return fmt.Sprintf("%.0f", size)
+	case size < m:
+		return fmt.Sprintf("%.1fK", size/k)
+	case size < b:
+		return fmt.Sprintf("%.1fM", size/m)
+	case size < t:
+		return fmt.Sprintf("%.1fB", size/b)
+	default:
+		return fmt.Sprintf("%.1fT", size/t)
+	}
 }

--- a/util/toputils_test.go
+++ b/util/toputils_test.go
@@ -184,7 +184,101 @@ func TestPsize(t *testing.T) {
 			got := Psize(testcase.args.displayRawBytes, testcase.args.input)
 
 			if got != testcase.want {
-				t.Errorf("%s wanted \"%s\", got \"%s\"", testcase.description, testcase.want, got)
+				t.Errorf("%s wanted %q, got %q", testcase.description, testcase.want, got)
+			}
+		})
+	}
+}
+
+func TestNsize(t *testing.T) {
+
+	type Args struct {
+		displayRawBytes bool
+		input           int64
+	}
+
+	testcases := map[string]struct{
+		args        Args
+		want        string
+	}{
+		"given input 999 and display_raw_bytes false": {
+			args: Args{
+				input:           int64(999),
+				displayRawBytes: false,
+			},
+			want: "999",
+		},
+		"given input 1000 and display_raw_bytes false": {
+			args: Args{
+				input:           int64(1000),
+				displayRawBytes: false,
+			},
+			want: "1.0K",
+		},
+		"given input 1_000_000 and display_raw_bytes false": {
+			args: Args{
+				input:           int64(1_000_000),
+				displayRawBytes: false,
+			},
+			want: "1.0M",
+		},
+		"given input 1_000_000_000 and display_raw_bytes false": {
+			args: Args{
+				input:           int64(1_000_000_000),
+				displayRawBytes: false,
+			},
+			want: "1.0B",
+		},
+		"given input 1_000_000_000_000 and display_raw_bytes false": {
+			args: Args{
+				input:           int64(1_000_000_000_000),
+				displayRawBytes: false,
+			},
+			want: "1.0T",
+		},
+		"given input 999 and display_raw_bytes true": {
+			args: Args{
+				input:           int64(999),
+				displayRawBytes: true,
+			},
+			want: "999",
+		},
+		"given input 1000 and display_raw_bytes true": {
+			args: Args{
+				input:           int64(1000),
+				displayRawBytes: true,
+			},
+			want: "1000",
+		},
+		"given input 1_000_000 and display_raw_bytes true": {
+			args: Args{
+				input:           int64(1_000_000),
+				displayRawBytes: true,
+			},
+			want: "1000000",
+		},
+		"given input 1_000_000_000 and display_raw_bytes true": {
+			args: Args{
+				input:           int64(1_000_000_000),
+				displayRawBytes: true,
+			},
+			want: "1000000000",
+		},
+		"given input 1_000_000_000_000 and display_raw_bytes true": {
+			args: Args{
+				input:           int64(1_000_000_000_000),
+				displayRawBytes: true,
+			},
+			want: "1000000000000",
+		},
+	}
+
+	for name, testcase := range testcases {
+		t.Run(name, func(t *testing.T) {
+			got := Nsize(testcase.args.displayRawBytes, testcase.args.input)
+
+			if got != testcase.want {
+				t.Errorf("wanted %q, got %q", testcase.want, got)
 			}
 		})
 	}


### PR DESCRIPTION
This is a possible fix for the number display issue presented in #83.

I have added a new function `Nsize` (With tests) that returns a human readable string representation of a number, but to be used for numbers that are not bytes like message counts.

I don't know if the the new function name `Nsize` is OK, I tried to be consistent with `Psize`.

For example the new function changes how these numbers are displayed:
- `1000`: Previously `1000` now `1.0K`
- `1_000_000`: Previously `976.6K` now `1.0M`
- `1_000_000_000`: Previously `953.7M` now `1.0B`
- `1_000_000_000_000`: Previously `931.3G` now `1.0T`