### PR TITLE
Make an initial fetch request before entering the loop

### DIFF
--- a/util/toputils.go
+++ b/util/toputils.go
@@ -96,13 +96,18 @@ func (engine *Engine) Request(path string) (interface{}, error) {
 // MonitorStats is ran as a goroutine and takes options
 // which can modify how poll values then sends to channel.
 func (engine *Engine) MonitorStats() error {
+	// Initial fetch.
+	engine.StatsCh <- engine.fetchStats()
+
 	delay := time.Duration(engine.Delay) * time.Second
+	ticker := time.NewTicker(delay)
+	defer ticker.Stop()
 
 	for {
 		select {
 		case <-engine.ShutdownCh:
 			return nil
-		case <-time.After(delay):
+		case <-ticker.C:
 			engine.StatsCh <- engine.fetchStats()
 		}
 	}

--- a/util/toputils_test.go
+++ b/util/toputils_test.go
@@ -197,9 +197,9 @@ func TestNsize(t *testing.T) {
 		input           int64
 	}
 
-	testcases := map[string]struct{
-		args        Args
-		want        string
+	testcases := map[string]struct {
+		args Args
+		want string
 	}{
 		"given input 999 and display_raw_bytes false": {
 			args: Args{
@@ -285,7 +285,7 @@ func TestNsize(t *testing.T) {
 }
 
 func TestMonitorStats(t *testing.T) {
-	engine := NewEngine("127.0.0.1", server.DEFAULT_HTTP_PORT, 10, 1)
+	engine := NewEngine("127.0.0.1", server.DEFAULT_HTTP_PORT, 10, 5) // 5s delay
 	engine.SetupHTTP()
 	s := runMonitorServer(server.DEFAULT_HTTP_PORT)
 	defer s.Shutdown()


### PR DESCRIPTION
I've noticed that the tests take about 5 seconds to run and I wanted to improve this time, also I noticed that `nats-top` was waiting for the refresh interval (default `1s`) to make the first fetch request.

This more apparent if you set the refresh interval to a larger value for example `5s`:
```sh
nats-top -s demo.nats.io -ms 8222 -d 5
```

The program will display the empty state for `5s` until it makes the first request.

This pull request makes these changes:
- Change [`MonitorStats()`](https://github.com/nats-io/nats-top/blob/4bbff032818e8f961e7019cce6fea6c8272b809b/util/toputils.go#L98) to make an initial fetch request before entering the loop
- Use a `time.Ticker` instead of `time.After` in the loop
- Change the test `TestMonitorStats()` to add a refresh interval `5s` larger than the timeout `3s` (instead of adding another test which will be an exact copy of this test)

This changes 2 things:
- There's no initial delay when starting the program
- The tests run faster, from `~5s` to `~1s` (I will create a new pull request for more test improvements later)